### PR TITLE
Update monospacifier.py

### DIFF
--- a/monospacifier.py
+++ b/monospacifier.py
@@ -63,8 +63,8 @@ class GlyphScaler:
     @staticmethod
     def set_width(glyph, width):
         delta = width - glyph.width
-        glyph.left_side_bearing += delta / 2
-        glyph.right_side_bearing += delta - glyph.left_side_bearing
+        glyph.left_side_bearing = int(math.round(glyph.left_side_bearing + delta / 2))
+        glyph.right_side_bearing = int(math.round(glyph.right_side_bearing + delta - glyph.left_side_bearing))
         glyph.width = width
 
 class BasicGlyphScaler(GlyphScaler):

--- a/monospacifier.py
+++ b/monospacifier.py
@@ -63,8 +63,8 @@ class GlyphScaler:
     @staticmethod
     def set_width(glyph, width):
         delta = width - glyph.width
-        glyph.left_side_bearing = int(math.round(glyph.left_side_bearing + delta / 2))
-        glyph.right_side_bearing = int(math.round(glyph.right_side_bearing + delta - glyph.left_side_bearing))
+        glyph.left_side_bearing = int(round(glyph.left_side_bearing + delta / 2))
+        glyph.right_side_bearing = int(round(glyph.right_side_bearing + delta - glyph.left_side_bearing))
         glyph.width = width
 
 class BasicGlyphScaler(GlyphScaler):


### PR DESCRIPTION
Due to a potential bug in font-forge, the right/left side glyph bearings need integers, despite error messages claiming to need floats.