### PR TITLE
Bugfix composite glyphs

### DIFF
--- a/monospacifier.py
+++ b/monospacifier.py
@@ -63,8 +63,8 @@ class GlyphScaler:
     @staticmethod
     def set_width(glyph, width):
         delta = width - glyph.width
-        glyph.left_side_bearing += delta / 2
-        glyph.right_side_bearing += delta - glyph.left_side_bearing
+        glyph.left_side_bearing = round(glyph.left_side_bearing + delta / 2)
+        # right_size_bearing will be automatically adjusted by Fontforge when width is changed
         glyph.width = width
 
 class BasicGlyphScaler(GlyphScaler):
@@ -168,7 +168,9 @@ class FontScaler:
         Adjust width of glyphs in using SCALER.
         """
         # counter = Counter()
-        for glyph in self.font.glyphs():
+        sorted_glyphs = [ v for v in self.font.glyphs() if v ]
+        sorted_glyphs.sort(key=lambda g: bool(g.references)) # modify glyphs with references after simple ones
+        for glyph in sorted_glyphs:
             scaler.scale(glyph)
             # counter[glyph.width] += 1
         # print("> Final width distribution: {}".format(", ".join(map(str, counter.most_common(10)))))

--- a/monospacifier.py
+++ b/monospacifier.py
@@ -168,9 +168,9 @@ class FontScaler:
         Adjust width of glyphs in using SCALER.
         """
         # counter = Counter()
-        sorted_glyphs = [ v for v in self.font.glyphs() if v ]
-        sorted_glyphs.sort(key=lambda g: bool(g.references)) # modify glyphs with references after simple ones
-        for glyph in sorted_glyphs:
+        for glyph in self.font.glyphs():
+            glyph.unlinkRef()
+        for glyph in self.font.glyphs():
             scaler.scale(glyph)
             # counter[glyph.width] += 1
         # print("> Final width distribution: {}".format(", ".join(map(str, counter.most_common(10)))))


### PR DESCRIPTION
**[why]**
Glyphs with references, for example a `i acute` that is assembled (in some
fonts) from `dottless i` and `actue` fail  to come out with correct
bearings.

**[how]**
It is rather hard to adjust all the layers correctly.
The simple approach is to replace the composit glyphs with their actual
component-outlines. After that the scaling can happen as any ordinary
glyph.
    
The drawback is that the font needs more memory, especially if it has a
large amount of composite glyphs.
    
We need to do this in two loops because the unlinking must happen before
any referenced glyph has been modified.

**[note]**
Also fix some code already fixed in PR #34 here for convenience.

Fixes: #29 
Fixes: #32
Fixes: https://github.com/fontforge/fontforge/issues/5222

Related: #25